### PR TITLE
Fix edge case with negative values in replicateM

### DIFF
--- a/src/Control/Monad.purs
+++ b/src/Control/Monad.purs
@@ -1,11 +1,12 @@
 module Control.Monad where
 
 replicateM :: forall m a. (Monad m) => Number -> m a -> m [a]
-replicateM 0 _ = return []
-replicateM n m = do
-  a <- m
-  as <- replicateM (n - 1) m
-  return (a : as)
+replicateM n m
+  | n >= 1 = do
+    a <- m
+    as <- replicateM (n - 1) m
+    return (a : as)
+  | otherwise = return []
 
 foldM :: forall m a b. (Monad m) => (a -> b -> m a) -> a -> [b] -> m a
 foldM _ a [] = return a


### PR DESCRIPTION
This treats negative numbers the same as 0, rather than blowing the
stack. I used >= 1 because we are using a number which could
unfortunately be a floating point, so this basically rounds down in that
extreme edge case. Ideally this would use nats or integers but thats a
separate issue.