### PR TITLE
Added `mfilter`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 ### Type Classes
 
+
     class (Functor f) <= Alt f where
+
       (<|>) :: forall a. f a -> f a -> f a
 
 
@@ -12,12 +14,15 @@
 
 ### Type Classes
 
+
     class (Applicative f, Plus f) <= Alternative f where
 
 
 ### Values
 
+
     many :: forall f a. (Alternative f, Lazy1 f) => f a -> f [a]
+
 
     some :: forall f a. (Alternative f, Lazy1 f) => f a -> f [a]
 
@@ -26,17 +31,24 @@
 
 ### Values
 
+
     (*>) :: forall a b f. (Apply f) => f a -> f b -> f b
+
 
     (<*) :: forall a b f. (Apply f) => f a -> f b -> f a
 
+
     forever :: forall a b f. (Apply f) => f a -> f b
+
 
     lift2 :: forall a b c f. (Apply f) => (a -> b -> c) -> f a -> f b -> f c
 
+
     lift3 :: forall a b c d f. (Apply f) => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
 
+
     lift4 :: forall a b c d e f. (Apply f) => (a -> b -> c -> d -> e) -> f a -> f b -> f c -> f d -> f e
+
 
     lift5 :: forall a b c d e f g. (Apply f) => (a -> b -> c -> d -> e -> g) -> f a -> f b -> f c -> f d -> f e -> f g
 
@@ -45,13 +57,18 @@
 
 ### Values
 
+
     (<=<) :: forall a b c m. (Bind m) => (b -> m c) -> (a -> m b) -> a -> m c
+
 
     (=<<) :: forall a b m. (Bind m) => (a -> m b) -> m a -> m b
 
+
     (>=>) :: forall a b c m. (Bind m) => (a -> m b) -> (b -> m c) -> a -> m c
 
+
     ifM :: forall a m. (Bind m) => m Boolean -> m a -> m a -> m a
+
 
     join :: forall a m. (Bind m) => m (m a) -> m a
 
@@ -60,7 +77,9 @@
 
 ### Type Classes
 
+
     class (Extend w) <= Comonad w where
+
       extract :: forall a. w a -> a
 
 
@@ -68,22 +87,29 @@
 
 ### Type Classes
 
+
     class (Functor w) <= Extend w where
+
       (<<=) :: forall b a. (w a -> b) -> w a -> w b
 
 
 ### Type Class Instances
+
 
     instance extendArr :: (Semigroup w) => Extend (Prim.Function w)
 
 
 ### Values
 
+
     (=<=) :: forall b a w c. (Extend w) => (w b -> c) -> (w a -> b) -> w a -> c
+
 
     (=>=) :: forall b a w c. (Extend w) => (w a -> b) -> (w b -> c) -> w a -> c
 
+
     (=>>) :: forall b a w. (Extend w) => w a -> (w a -> b) -> w b
+
 
     duplicate :: forall a w. (Extend w) => w a -> w (w a)
 
@@ -92,7 +118,9 @@
 
 ### Values
 
+
     ($>) :: forall f a b. (Functor f) => f a -> b -> f b
+
 
     (<$) :: forall f a b. (Functor f) => a -> f b -> f a
 
@@ -101,21 +129,30 @@
 
 ### Type Classes
 
+
     class Lazy l where
+
       defer :: (Unit -> l) -> l
 
+
     class Lazy1 l where
+
       defer1 :: forall a. (Unit -> l a) -> l a
 
+
     class Lazy2 l where
+
       defer2 :: forall a b. (Unit -> l a b) -> l a b
 
 
 ### Values
 
+
     fix :: forall l a. (Lazy l) => (l -> l) -> l
 
+
     fix1 :: forall l a. (Lazy1 l) => (l a -> l a) -> l a
+
 
     fix2 :: forall l a b. (Lazy2 l) => (l a b -> l a b) -> l a b
 
@@ -124,11 +161,15 @@
 
 ### Values
 
+
     foldM :: forall m a b. (Monad m) => (a -> b -> m a) -> a -> [b] -> m a
+
 
     replicateM :: forall m a. (Monad m) => Number -> m a -> m [a]
 
+
     unless :: forall m. (Monad m) => Boolean -> m Unit -> m Unit
+
 
     when :: forall m. (Monad m) => Boolean -> m Unit -> m Unit
 
@@ -137,17 +178,24 @@
 
 ### Type Classes
 
+
     class (Monad m, Alternative m) <= MonadPlus m where
 
 
 ### Values
 
+
     guard :: forall m. (MonadPlus m) => Boolean -> m Unit
+
+
+    mfilter :: forall m a. (MonadPlus m) => (a -> Boolean) -> m a -> m a
 
 
 ## Module Control.Plus
 
 ### Type Classes
 
+
     class (Alt f) <= Plus f where
+
       empty :: forall a. f a

--- a/src/Control/MonadPlus.purs
+++ b/src/Control/MonadPlus.purs
@@ -8,3 +8,6 @@ class (Monad m, Alternative m) <= MonadPlus m
 guard :: forall m. (MonadPlus m) => Boolean -> m Unit
 guard true = return unit
 guard false = empty
+
+mfilter :: forall m a. (MonadPlus m) => (a -> Boolean) -> m a -> m a
+mfilter p v = v >>= \a -> if p a then pure a else empty


### PR DESCRIPTION
Can we make this more general? I mean, we could piece together the constraints:

```purescript
mfilter :: forall a f. (Plus f, Applicative f, Bind f) => (a -> Boolean) -> f a -> f a
```

Which kind of makes sense as `MonadPlus` implies a bunch of laws that these individual constraints don't, including `Alternative` and `Monad` laws. But then, where does it go? And is it useful enough to do that?