### PR TITLE
Add `extend` instance for `Array`

### DIFF
--- a/src/Control/Extend.js
+++ b/src/Control/Extend.js
@@ -1,0 +1,9 @@
+"use strict";
+
+exports.arrayExtend = function(f) {
+  return function(xs) {
+    return xs.map(function (_, i, xs) {
+      return f(xs.slice(i));
+    });
+  };
+};

--- a/src/Control/Extend.purs
+++ b/src/Control/Extend.purs
@@ -27,6 +27,11 @@ class Functor w <= Extend w where
 instance extendFn :: Semigroup w => Extend ((->) w) where
   extend f g w = f \w' -> g (w <> w')
 
+foreign import arrayExtend :: forall a b. (Array a -> b) -> Array a -> Array b
+
+instance extendArray :: Extend Array where
+  extend = arrayExtend
+
 infixr 1 extend as <<=
 
 -- | A version of `extend` with its arguments flipped.


### PR DESCRIPTION
With some advice from @garyb, I've added the `arrayExtend` function (via FFI, needs must), and given `Array` an `Extend` implementation. Behaviour is hopefully as expected:

```
> extend sum [10,5,4,3]
[22,12,7,3]

> extend sum [] :: Array Int
[]
```