### PR TITLE
Don’t let MonadZero imply its deprecation warning

### DIFF
--- a/src/Control/MonadZero.purs
+++ b/src/Control/MonadZero.purs
@@ -9,7 +9,7 @@
 -- | Use `Monad` and `Alternative` constraints instead.
 
 module Control.MonadZero
-  ( class Deprecated
+  ( class DeprecatedMonadZero
   , class MonadZero
   , module Control.Alt
   , module Control.Alternative
@@ -33,8 +33,8 @@ import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
 
 import Prim.TypeError (class Warn, Text)
 
-class Deprecated
-instance deprecated :: Warn (Text "'MonadZero' is deprecated, use 'Monad' and 'Alternative' constraints instead") => Deprecated
+class DeprecatedMonadZero
+instance deprecatedMonadZero :: Warn (Text "'MonadZero' is deprecated, use 'Monad' and 'Alternative' constraints instead") => DeprecatedMonadZero
 
 -- | The `MonadZero` type class has no members of its own; it just specifies
 -- | that the type has both `Monad` and `Alternative` instances.
@@ -43,6 +43,6 @@ instance deprecated :: Warn (Text "'MonadZero' is deprecated, use 'Monad' and 'A
 -- | laws:
 -- |
 -- | - Annihilation: `empty >>= f = empty`
-class (Monad m, Alternative m, Deprecated) <= MonadZero m
+class (Monad m, Alternative m, DeprecatedMonadZero) <= MonadZero m
 
 instance monadZeroArray :: MonadZero Array

--- a/src/Control/MonadZero.purs
+++ b/src/Control/MonadZero.purs
@@ -9,7 +9,7 @@
 -- | Use `Monad` and `Alternative` constraints instead.
 
 module Control.MonadZero
-  ( class DeprecatedMonadZero
+  ( class MonadZeroIsDeprecated
   , class MonadZero
   , module Control.Alt
   , module Control.Alternative
@@ -33,8 +33,8 @@ import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
 
 import Prim.TypeError (class Warn, Text)
 
-class DeprecatedMonadZero
-instance deprecatedMonadZero :: Warn (Text "'MonadZero' is deprecated, use 'Monad' and 'Alternative' constraints instead") => DeprecatedMonadZero
+class MonadZeroIsDeprecated
+instance monadZeroIsDeprecated :: Warn (Text "'MonadZero' is deprecated, use 'Monad' and 'Alternative' constraints instead") => MonadZeroIsDeprecated
 
 -- | The `MonadZero` type class has no members of its own; it just specifies
 -- | that the type has both `Monad` and `Alternative` instances.
@@ -43,6 +43,6 @@ instance deprecatedMonadZero :: Warn (Text "'MonadZero' is deprecated, use 'Mona
 -- | laws:
 -- |
 -- | - Annihilation: `empty >>= f = empty`
-class (Monad m, Alternative m, DeprecatedMonadZero) <= MonadZero m
+class (Monad m, Alternative m, MonadZeroIsDeprecated) <= MonadZero m
 
 instance monadZeroArray :: MonadZero Array

--- a/src/Control/MonadZero.purs
+++ b/src/Control/MonadZero.purs
@@ -9,7 +9,8 @@
 -- | Use `Monad` and `Alternative` constraints instead.
 
 module Control.MonadZero
-  ( class MonadZero
+  ( class Deprecated
+  , class MonadZero
   , module Control.Alt
   , module Control.Alternative
   , module Control.Applicative
@@ -32,6 +33,9 @@ import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
 
 import Prim.TypeError (class Warn, Text)
 
+class Deprecated
+instance deprecated :: Warn (Text "'MonadZero' is deprecated, use 'Monad' and 'Alternative' constraints instead") => Deprecated
+
 -- | The `MonadZero` type class has no members of its own; it just specifies
 -- | that the type has both `Monad` and `Alternative` instances.
 -- |
@@ -39,6 +43,6 @@ import Prim.TypeError (class Warn, Text)
 -- | laws:
 -- |
 -- | - Annihilation: `empty >>= f = empty`
-class (Monad m, Alternative m, Warn (Text "'MonadZero' is deprecated, use 'Monad' and 'Alternative' constraints instead")) <= MonadZero m
+class (Monad m, Alternative m, Deprecated) <= MonadZero m
 
 instance monadZeroArray :: MonadZero Array


### PR DESCRIPTION
Otherwise instances with a MonadZero constraint in their context hide the warning.