### PR TITLE
Minor simplification of foreign arrayExtend

### DIFF
--- a/src/Control/Extend.js
+++ b/src/Control/Extend.js
@@ -2,7 +2,7 @@
 
 exports.arrayExtend = function(f) {
   return function(xs) {
-    return xs.map(function (_, i, xs) {
+    return xs.map(function (_, i) {
       return f(xs.slice(i));
     });
   };


### PR DESCRIPTION
Seems like taking the optional array argument in the map callback is unnecessary (unless there's some performance reason for writing it this way). @i-am-tom for clarification.
I think this simplified version will make it more obvious what's going on.
