### PR TITLE
Add Function instance to Comonad to match Extend instance

### DIFF
--- a/src/Control/Comonad.purs
+++ b/src/Control/Comonad.purs
@@ -7,6 +7,7 @@ module Control.Comonad
 import Control.Extend (class Extend, duplicate, extend, (<<=), (=<=), (=>=), (=>>))
 
 import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
+import Data.Monoid (class Monoid, mempty)
 
 -- | `Comonad` extends the `Extend` class with the `extract` function
 -- | which extracts a value, discarding the comonadic context.
@@ -19,3 +20,6 @@ import Data.Functor (class Functor, map, void, ($>), (<#>), (<$), (<$>))
 -- | - Right Identity: `extract (f <<= xs) = f xs`
 class Extend w <= Comonad w where
   extract :: forall a. w a -> a
+
+instance comonadFn :: Monoid m => Comonad ((->) m) where
+  extract f = f mempty


### PR DESCRIPTION
Comonad has Monoid function instance to  match instance for Semigroups in Control.Extend